### PR TITLE
install latest v6 version of npm

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -113,7 +113,7 @@ cd $build_dir
 
 # Install npm@next
 status "Installing the 'latest' version of npm"
-npm install -g npm@latest 2>&1 | indent
+npm install -g npm@latest-6 2>&1 | indent
 npm_version=$(npm -v)
 status "Using npm version: $npm_version"
 


### PR DESCRIPTION
Seems like npm pushed a breaking change that's effecting older versions of node. Issue and proposed fix below - doesn't sounds sound like they plan on addressing it but I'll check back on the issue tomorrow - there is a lot of activity on it.

https://github.com/npm/cli/issues/2599